### PR TITLE
Use container-based infrastructure for faster builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
+sudo: false
 language: node_js
 node_js:
-  - 0.12.7
+  - "5"
+  - "4"
+  - "iojs"
+  - "0.12"
 notifications:
   email:
     - a@alexandresaiz.com
 deploy:
- api_key:
- email: a@alexandresaiz.com
- provider: npm
+  api_key:
+  email: a@alexandresaiz.com
+  provider: npm


### PR DESCRIPTION
This patch brings the following changes:
- Add `sudo: false` to [speed up the build](http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/).
- Test node `5`, `4` and `iojs`.

Closes #45.