### PR TITLE
Remove arguments validation

### DIFF
--- a/lib/resources/application_charge.js
+++ b/lib/resources/application_charge.js
@@ -19,9 +19,6 @@
 
     ApplicationCharge.prototype.activate = function(id, fields, callback) {
       var url;
-      if (id == null) {
-        callback(new Error('missing id'));
-      }
       url = this.resource.queryString(this.prefix + "/" + id + "/activate");
       return this.resource.post(url, this.slug, fields, callback);
     };

--- a/lib/resources/base.js
+++ b/lib/resources/base.js
@@ -39,9 +39,6 @@
       if (typeof params === 'function') {
         ref = [callback, params], params = ref[0], callback = ref[1];
       }
-      if (id == null) {
-        callback(new Error('missing id'));
-      }
       url = this.resource.queryString(this.prefix + "/" + id, params);
       return this.resource.get(url, this.slug, callback);
     };
@@ -54,18 +51,12 @@
 
     Base.prototype.update = function(id, fields, callback) {
       var url;
-      if (id == null) {
-        callback(new Error('missing id'));
-      }
       url = this.resource.queryString(this.prefix + "/" + id);
       return this.resource.put(url, this.slug, fields, callback);
     };
 
     Base.prototype["delete"] = function(id, callback) {
       var url;
-      if (id == null) {
-        callback(new Error('missing'));
-      }
       url = this.resource.queryString(this.prefix + "/" + id);
       return this.resource["delete"](url, id, callback);
     };

--- a/lib/resources/base_child.js
+++ b/lib/resources/base_child.js
@@ -42,9 +42,6 @@
       if (typeof params === 'function') {
         ref = [callback, params], params = ref[0], callback = ref[1];
       }
-      if (id == null) {
-        callback(new Error('missing id'));
-      }
       url = this.resource.queryString(this.prefix + "/" + parentId + this.child + "/" + id, params);
       return this.resource.get(url, this.slug, callback);
     };
@@ -57,18 +54,12 @@
 
     BaseChild.prototype.update = function(parentId, id, fields, callback) {
       var url;
-      if (id == null) {
-        callback(new Error('missing id'));
-      }
       url = this.resource.queryString(this.prefix + "/" + parentId + this.child + "/" + id);
       return this.resource.put(url, this.slug, fields, callback);
     };
 
     BaseChild.prototype["delete"] = function(parentId, id, callback) {
       var url;
-      if (id == null) {
-        callback(new Error('missing'));
-      }
       url = this.resource.queryString(this.prefix + "/" + parentId + this.child + "/" + id);
       return this.resource["delete"](url, id, callback);
     };

--- a/lib/resources/comment.js
+++ b/lib/resources/comment.js
@@ -19,36 +19,24 @@
 
     Comment.prototype.spam = function(id, callback) {
       var url;
-      if (id == null) {
-        callback(new Error('missing id'));
-      }
       url = this.resource.queryString(this.prefix + "/" + id + "/spam");
       return this.resource.post(url, "", callback);
     };
 
     Comment.prototype.notSpam = function(id, callback) {
       var url;
-      if (id == null) {
-        callback(new Error('missing id'));
-      }
       url = this.resource.queryString(this.prefix + "/" + id + "/not_spam");
       return this.resource.post(url, "", callback);
     };
 
     Comment.prototype.approve = function(id, callback) {
       var url;
-      if (id == null) {
-        callback(new Error('missing id'));
-      }
       url = this.resource.queryString(this.prefix + "/" + id + "/approve");
       return this.resource.post(url, "", callback);
     };
 
     Comment.prototype.remove = function(id, callback) {
       var url;
-      if (id == null) {
-        callback(new Error('missing id'));
-      }
       url = this.resource.queryString(this.prefix + "/" + id + "/remove");
       return this.resource.post(url, "", callback);
     };

--- a/lib/resources/customer_group.js
+++ b/lib/resources/customer_group.js
@@ -19,9 +19,6 @@
 
     CustomerGroup.prototype.customers = function(id, callback) {
       var url;
-      if (id == null) {
-        callback(new Error('missing id'));
-      }
       url = this.resource.queryString(this.prefix + "/" + id + "/customers");
       return this.resource.post(url, "customers", callback);
     };

--- a/lib/resources/customer_saved_search.js
+++ b/lib/resources/customer_saved_search.js
@@ -28,9 +28,6 @@
 
     CustomerSavedSearch.prototype.getCustomersForId = function(id, callback) {
       var url;
-      if (id == null) {
-        callback(new Error('missing id'));
-      }
       url = this.resource.queryString(this.prefix + "/" + id + "/customers");
       return this.resource.get(url, "customers", callback);
     };

--- a/lib/resources/discount.js
+++ b/lib/resources/discount.js
@@ -17,28 +17,14 @@
       Discount.__super__.constructor.call(this, site);
     }
 
-    Discount.prototype._isIdValid = function(id) {
-      var ref;
-      if (((ref = typeof id) !== 'string' && ref !== 'number') || id !== 0 && !id) {
-        return false;
-      }
-      return true;
-    };
-
     Discount.prototype.disable = function(id, callback) {
       var url;
-      if (!this._isIdValid(id)) {
-        return callback(new Error('invalid or missing id'));
-      }
       url = this.resource.queryString(this.prefix + "/" + id + "/disable");
       return this.resource.post(url, this.slug, callback);
     };
 
     Discount.prototype.enable = function(id, callback) {
       var url;
-      if (!this._isIdValid(id)) {
-        return callback(new Error('invalid or missing id'));
-      }
       url = this.resource.queryString(this.prefix + "/" + id + "/enable");
       return this.resource.post(url, this.slug, callback);
     };

--- a/lib/resources/fulfillment.js
+++ b/lib/resources/fulfillment.js
@@ -21,18 +21,12 @@
 
     Fulfillment.prototype.complete = function(orderId, id, callback) {
       var url;
-      if (id == null) {
-        callback(new Error('missing id'));
-      }
       url = this.resource.queryString(this.prefix + "/" + orderId + this.child + "/" + id + "/complete");
       return this.resource.post(url, this.slug, callback);
     };
 
     Fulfillment.prototype.cancel = function(orderId, id, callback) {
       var url;
-      if (id == null) {
-        callback(new Error('missing id'));
-      }
       url = this.resource.queryString(this.prefix + "/" + orderId + this.child + "/" + id + "/cancel");
       return this.resource.post(url, this.slug, callback);
     };

--- a/lib/resources/gift_card.js
+++ b/lib/resources/gift_card.js
@@ -23,18 +23,7 @@
       return this.all(callback);
     };
 
-    GiftCard.prototype._isStatusValid = function(status) {
-      if (~["disabled", "enabled"].indexOf(status)) {
-        return true;
-      } else {
-        return false;
-      }
-    };
-
     GiftCard.prototype.getByStatus = function(status, callback) {
-      if (!this._isStatusValid(status)) {
-        return callback(new Error('status is not valid'));
-      }
       return this.all({
         status: status
       }, callback);
@@ -45,9 +34,6 @@
     };
 
     GiftCard.prototype.getCountByStatus = function(status, callback) {
-      if (!this._isStatusValid(status)) {
-        return callback(new Error('status is not valid'));
-      }
       return this.count({
         status: status
       }, callback);
@@ -64,9 +50,6 @@
 
     GiftCard.prototype.disable = function(id, callback) {
       var params, url;
-      if (id == null) {
-        callback(new Error('missing id'));
-      }
       url = this.resource.queryString(this.prefix + "/" + id + "/disable");
       params = {
         id: id

--- a/lib/resources/order.js
+++ b/lib/resources/order.js
@@ -22,18 +22,12 @@
 
     Order.prototype.close = function(id, callback) {
       var url;
-      if (id == null) {
-        callback(new Error('missing id'));
-      }
       url = this.resource.queryString(this.prefix + "/" + id + "/close");
       return this.resource.get(url, this.slug, callback);
     };
 
     Order.prototype.open = function(id, callback) {
       var url;
-      if (id == null) {
-        callback(new Error('missing id'));
-      }
       url = this.resource.queryString(this.prefix + "/" + id + "/open");
       return this.resource.get(url, this.slug, callback);
     };
@@ -43,9 +37,6 @@
       if (typeof params === 'function') {
         ref = [callback, params], params = ref[0], callback = ref[1];
       }
-      if (id == null) {
-        callback(new Error('missing id'));
-      }
       url = this.resource.queryString(this.prefix + "/" + id + "/cancel", params);
       return this.resource.get(url, this.slug, callback);
     };
@@ -54,9 +45,6 @@
       var ref, url;
       if (typeof params === 'function') {
         ref = [callback, params], params = ref[0], callback = ref[1];
-      }
-      if (id == null) {
-        callback(new Error('missing id'));
       }
       url = this.resource.queryString(this.prefix + "/" + id + "/events", params);
       return this.resource.get(url, "events", callback);

--- a/lib/resources/page.js
+++ b/lib/resources/page.js
@@ -25,9 +25,6 @@
       if (typeof params === 'function') {
         ref = [callback, params], params = ref[0], callback = ref[1];
       }
-      if (id == null) {
-        callback(new Error('missing id'));
-      }
       url = this.resource.queryString(this.prefix + "/" + id + "/events", params);
       return this.resource.get(url, "events", callback);
     };

--- a/lib/resources/product.js
+++ b/lib/resources/product.js
@@ -25,9 +25,6 @@
       if (typeof params === 'function') {
         ref = [callback, params], params = ref[0], callback = ref[1];
       }
-      if (id == null) {
-        callback(new Error('missing id'));
-      }
       url = this.resource.queryString(this.prefix + "/" + id + "/events", params);
       return this.resource.get(url, "events", callback);
     };

--- a/lib/resources/product_variant.js
+++ b/lib/resources/product_variant.js
@@ -26,26 +26,20 @@
       if (typeof params === 'function') {
         ref = [callback, params], params = ref[0], callback = ref[1];
       }
-      if (id == null) {
-        callback(new Error('missing id'));
-      }
       url = this.resource.queryString("" + this.site + this.child + "/" + id, params);
       return this.resource.get(url, this.slug, callback);
     };
 
     ProductVariant.prototype.update = function(id, fields, callback) {
       var url;
-      if (id == null) {
-        callback(new Error('missing id'));
-      }
       url = this.resource.queryString("" + this.site + this.child + "/" + id);
       return this.resource.put(url, this.slug, fields, callback);
     };
 
-    module.exports = ProductVariant;
-
     return ProductVariant;
 
   })(BaseChild);
+
+  module.exports = ProductVariant;
 
 }).call(this);

--- a/lib/resources/recurring_application_charge.js
+++ b/lib/resources/recurring_application_charge.js
@@ -19,9 +19,6 @@
 
     RecurringApplicationCharge.prototype.activate = function(id, fields, callback) {
       var url;
-      if (id == null) {
-        callback(new Error('missing id'));
-      }
       url = this.resource.queryString(this.prefix + "/" + id + "/activate");
       return this.resource.post(url, this.slug, fields, callback);
     };

--- a/src/resources/application_charge.coffee
+++ b/src/resources/application_charge.coffee
@@ -1,17 +1,14 @@
 Base = require './base'
 
 class ApplicationCharge extends Base
-	slug: "application_charge"
-	prefix: "/application_charges"
+  slug: "application_charge"
+  prefix: "/application_charges"
 
-	constructor: (site) ->
-		super(site)
+  constructor: (site) ->
+    super(site)
 
-	activate: (id, fields, callback) ->
-		callback new Error 'missing id' unless id?
-		url = @resource.queryString "#{@prefix}/#{id}/activate"
-		@resource.post url, @slug, fields, callback
-
-
+  activate: (id, fields, callback) ->
+    url = @resource.queryString "#{@prefix}/#{id}/activate"
+    @resource.post url, @slug, fields, callback
 
 module.exports = ApplicationCharge

--- a/src/resources/base.coffee
+++ b/src/resources/base.coffee
@@ -1,43 +1,39 @@
 pluralize = require 'pluralize'
 
 class Base
-	slug: "base"
-	prefix: "/base"
-	resource: require '../resource'
+  slug: "base"
+  prefix: "/base"
+  resource: require '../resource'
 
-	constructor: (site) ->
-		@prefix = "#{site}#{@prefix}"
+  constructor: (site) ->
+    @prefix = "#{site}#{@prefix}"
 
-	all: (params, callback) ->
-		[params, callback] = [callback, params] if typeof params is 'function'
-		url = @resource.queryString @prefix, params
-		pluralizedSlug = pluralize(@slug)
-		@resource.get url, "#{pluralizedSlug}", callback
+  all: (params, callback) ->
+    [params, callback] = [callback, params] if typeof params is 'function'
+    url = @resource.queryString @prefix, params
+    pluralizedSlug = pluralize(@slug)
+    @resource.get url, "#{pluralizedSlug}", callback
 
-	count: (params, callback) ->
-		[params, callback] = [callback, params] if typeof params is 'function'
-		url = @resource.queryString "#{@prefix}/count", params
-		@resource.get url, "count", callback
+  count: (params, callback) ->
+    [params, callback] = [callback, params] if typeof params is 'function'
+    url = @resource.queryString "#{@prefix}/count", params
+    @resource.get url, "count", callback
 
-	get: (id, params, callback) ->
-		[params, callback] = [callback, params] if typeof params is 'function'
-		callback new Error 'missing id' unless id?
-		url = @resource.queryString "#{@prefix}/#{id}", params
-		@resource.get url, @slug, callback
+  get: (id, params, callback) ->
+    [params, callback] = [callback, params] if typeof params is 'function'
+    url = @resource.queryString "#{@prefix}/#{id}", params
+    @resource.get url, @slug, callback
 
-	create: (fields, callback) ->
-		url = @resource.queryString @prefix
-		@resource.post url, @slug, fields, callback
+  create: (fields, callback) ->
+    url = @resource.queryString @prefix
+    @resource.post url, @slug, fields, callback
 
-	update: (id, fields, callback) ->
-		callback new Error 'missing id' unless id?
-		url = @resource.queryString "#{@prefix}/#{id}"
-		@resource.put url, @slug, fields, callback
+  update: (id, fields, callback) ->
+    url = @resource.queryString "#{@prefix}/#{id}"
+    @resource.put url, @slug, fields, callback
 
-	delete: (id, callback) ->
-		callback new Error 'missing' unless id?
-		url = @resource.queryString "#{@prefix}/#{id}"
-		@resource.delete url, id, callback
-
+  delete: (id, callback) ->
+    url = @resource.queryString "#{@prefix}/#{id}"
+    @resource.delete url, id, callback
 
 module.exports = Base

--- a/src/resources/base_child.coffee
+++ b/src/resources/base_child.coffee
@@ -1,45 +1,41 @@
 pluralize = require 'pluralize'
 
 class BaseChild
-	parent: "/parent"
-	slug: "base"
-	child: "/base"
-	resource: require '../resource'
+  parent: "/parent"
+  slug: "base"
+  child: "/base"
+  resource: require '../resource'
 
-	constructor: (site) ->
-		@site = site
-		@prefix = "#{site}#{@parent}"
+  constructor: (site) ->
+    @site = site
+    @prefix = "#{site}#{@parent}"
 
-	all: (parentId, params, callback) ->
-		[params, callback] = [callback, params] if typeof params is 'function'
-		url = @resource.queryString "#{@prefix}/#{parentId}#{@child}", params
-		pluralizedSlug = pluralize(@slug)
-		@resource.get url, pluralizedSlug, callback
+  all: (parentId, params, callback) ->
+    [params, callback] = [callback, params] if typeof params is 'function'
+    url = @resource.queryString "#{@prefix}/#{parentId}#{@child}", params
+    pluralizedSlug = pluralize(@slug)
+    @resource.get url, pluralizedSlug, callback
 
-	count: (parentId, params, callback) ->
-		[params, callback] = [callback, params] if typeof params is 'function'
-		url = @resource.queryString "#{@prefix}/#{parentId}#{@child}/count", params
-		@resource.get url, "count", callback
+  count: (parentId, params, callback) ->
+    [params, callback] = [callback, params] if typeof params is 'function'
+    url = @resource.queryString "#{@prefix}/#{parentId}#{@child}/count", params
+    @resource.get url, "count", callback
 
-	get: (parentId, id, params, callback) ->
-		[params, callback] = [callback, params] if typeof params is 'function'
-		callback new Error 'missing id' unless id?
-		url = @resource.queryString "#{@prefix}/#{parentId}#{@child}/#{id}", params
-		@resource.get url, @slug, callback
+  get: (parentId, id, params, callback) ->
+    [params, callback] = [callback, params] if typeof params is 'function'
+    url = @resource.queryString "#{@prefix}/#{parentId}#{@child}/#{id}", params
+    @resource.get url, @slug, callback
 
-	create: (parentId, fields, callback) ->
-		url = @resource.queryString "#{@prefix}/#{parentId}#{@child}"
-		@resource.post url, @slug, fields, callback
+  create: (parentId, fields, callback) ->
+    url = @resource.queryString "#{@prefix}/#{parentId}#{@child}"
+    @resource.post url, @slug, fields, callback
 
-	update: (parentId, id, fields, callback) ->
-		callback new Error 'missing id' unless id?
-		url = @resource.queryString "#{@prefix}/#{parentId}#{@child}/#{id}"
-		@resource.put url, @slug, fields, callback
+  update: (parentId, id, fields, callback) ->
+    url = @resource.queryString "#{@prefix}/#{parentId}#{@child}/#{id}"
+    @resource.put url, @slug, fields, callback
 
-	delete: (parentId, id, callback) ->
-		callback new Error 'missing' unless id?
-		url = @resource.queryString "#{@prefix}/#{parentId}#{@child}/#{id}"
-		@resource.delete url, id, callback
-
+  delete: (parentId, id, callback) ->
+    url = @resource.queryString "#{@prefix}/#{parentId}#{@child}/#{id}"
+    @resource.delete url, id, callback
 
 module.exports = BaseChild

--- a/src/resources/comment.coffee
+++ b/src/resources/comment.coffee
@@ -1,35 +1,29 @@
 Base = require './base'
 
 class Comment extends Base
-	slug: "comment"
-	prefix: "/comments"
+  slug: "comment"
+  prefix: "/comments"
 
-	constructor: (site) ->
-		super(site)
+  constructor: (site) ->
+    super(site)
 
-	spam: (id, callback) ->
-		callback new Error 'missing id' unless id?
-		url = @resource.queryString "#{@prefix}/#{id}/spam"
-		@resource.post url, "", callback
+  spam: (id, callback) ->
+    url = @resource.queryString "#{@prefix}/#{id}/spam"
+    @resource.post url, "", callback
 
-	notSpam: (id, callback) ->
-		callback new Error 'missing id' unless id?
-		url = @resource.queryString "#{@prefix}/#{id}/not_spam"
-		@resource.post url, "", callback
+  notSpam: (id, callback) ->
+    url = @resource.queryString "#{@prefix}/#{id}/not_spam"
+    @resource.post url, "", callback
 
-	approve: (id, callback) ->
-		callback new Error 'missing id' unless id?
-		url = @resource.queryString "#{@prefix}/#{id}/approve"
-		@resource.post url, "", callback
+  approve: (id, callback) ->
+    url = @resource.queryString "#{@prefix}/#{id}/approve"
+    @resource.post url, "", callback
 
-	remove: (id, callback) ->
-		callback new Error 'missing id' unless id?
-		url = @resource.queryString "#{@prefix}/#{id}/remove"
-		@resource.post url, "", callback
+  remove: (id, callback) ->
+    url = @resource.queryString "#{@prefix}/#{id}/remove"
+    @resource.post url, "", callback
 
-	delete: (id, callback) ->
-		@remove(id, callback)
-
-
+  delete: (id, callback) ->
+    @remove(id, callback)
 
 module.exports = Comment

--- a/src/resources/customer_group.coffee
+++ b/src/resources/customer_group.coffee
@@ -1,16 +1,14 @@
 Base = require './base'
 
 class CustomerGroup extends Base
-	slug: "customer_group"
-	prefix: "/customer_groups"
+  slug: "customer_group"
+  prefix: "/customer_groups"
 
-	constructor: (site) ->
-		super(site)
+  constructor: (site) ->
+    super(site)
 
-	customers: (id, callback) ->
-		callback new Error 'missing id' unless id?
-		url = @resource.queryString "#{@prefix}/#{id}/customers"
-		@resource.post url, "customers", callback
-
+  customers: (id, callback) ->
+    url = @resource.queryString "#{@prefix}/#{id}/customers"
+    @resource.post url, "customers", callback
 
 module.exports = CustomerGroup

--- a/src/resources/customer_saved_search.coffee
+++ b/src/resources/customer_saved_search.coffee
@@ -1,21 +1,19 @@
 Base = require './base'
 
 class CustomerSavedSearch extends Base
-	slug: "customer_saved_search"
-	prefix: "/customer_saved_searches"
+  slug: "customer_saved_search"
+  prefix: "/customer_saved_searches"
 
-	constructor: (site) ->
-		super(site)
+  constructor: (site) ->
+    super(site)
 
-	all: (params, callback) ->
-		[params, callback] = [callback, params] if typeof params is 'function'
-		url = @resource.queryString @prefix, params
-		@resource.get url, "customer_saved_searches", callback
+  all: (params, callback) ->
+    [params, callback] = [callback, params] if typeof params is 'function'
+    url = @resource.queryString @prefix, params
+    @resource.get url, "customer_saved_searches", callback
 
-	getCustomersForId: (id, callback) ->
-		callback new Error 'missing id' unless id?
-		url = @resource.queryString "#{@prefix}/#{id}/customers"
-		@resource.get url, "customers", callback
-
+  getCustomersForId: (id, callback) ->
+    url = @resource.queryString "#{@prefix}/#{id}/customers"
+    @resource.get url, "customers", callback
 
 module.exports = CustomerSavedSearch

--- a/src/resources/discount.coffee
+++ b/src/resources/discount.coffee
@@ -7,19 +7,11 @@ class Discount extends Base
   constructor: (site) ->
     super(site)
 
-  _isIdValid: (id) ->
-    return false if typeof id not in ['string', 'number'] or id isnt 0 && !id
-    return true
-
   disable: (id, callback) ->
-    return callback new Error 'invalid or missing id' if !@_isIdValid id
-
     url = @resource.queryString "#{@prefix}/#{id}/disable"
     @resource.post url, @slug, callback
 
   enable: (id, callback) ->
-    return callback new Error 'invalid or missing id' if !@_isIdValid id
-
     url = @resource.queryString "#{@prefix}/#{id}/enable"
     @resource.post url, @slug, callback
 

--- a/src/resources/fulfillment.coffee
+++ b/src/resources/fulfillment.coffee
@@ -9,12 +9,10 @@ class Fulfillment extends BaseChild
 		super(site)
 
 	complete: (orderId, id, callback) ->
-		callback new Error 'missing id' unless id?
 		url = @resource.queryString "#{@prefix}/#{orderId}#{@child}/#{id}/complete"
 		@resource.post url, @slug, callback
 
 	cancel: (orderId, id, callback) ->
-		callback new Error 'missing id' unless id?
 		url = @resource.queryString "#{@prefix}/#{orderId}#{@child}/#{id}/cancel"
 		@resource.post url, @slug, callback
 

--- a/src/resources/gift_card.coffee
+++ b/src/resources/gift_card.coffee
@@ -4,24 +4,20 @@ pluralize = require 'pluralize'
 class GiftCard extends Base
   slug: 'gift_card'
   prefix: '/gift_cards'
+
   constructor: (site) ->
     super(site)
 
   getAll: (callback) ->
     @all(callback)
 
-  _isStatusValid: (status) ->
-    return if ~["disabled", "enabled"].indexOf(status) then yes else no
-
   getByStatus: (status, callback) ->
-    return callback new Error 'status is not valid' if !@_isStatusValid status
     @all({ status: status }, callback)
 
   getCount: (callback) ->
     @count(undefined, callback)
 
   getCountByStatus: (status, callback) ->
-    return callback new Error 'status is not valid' if !@_isStatusValid status
     @count({ status: status }, callback)
 
   search: (queryStr, callback) ->
@@ -30,12 +26,10 @@ class GiftCard extends Base
     @resource.get(url, pluralize(@slug), callback)
 
   disable: (id, callback) ->
-    callback new Error 'missing id' unless id?
     url = @resource.queryString "#{@prefix}/#{id}/disable"
 
     params = { id: id }
 
     @resource.post url, @slug, params, callback
-
 
 module.exports = GiftCard

--- a/src/resources/order.coffee
+++ b/src/resources/order.coffee
@@ -1,35 +1,30 @@
 Base = require './base'
 Metafields = require './metafield'
 
-class Order extends Base 
-	slug: "order"
-	prefix: "/orders"
+class Order extends Base
+  slug: "order"
+  prefix: "/orders"
 
-	constructor: (site) ->
-		@metafields = new Metafields(@prefix, site)
-		super(site)
+  constructor: (site) ->
+    @metafields = new Metafields(@prefix, site)
+    super(site)
 
-	close: (id, callback) ->
-		callback new Error 'missing id' unless id?
-		url = @resource.queryString "#{@prefix}/#{id}/close"
-		@resource.get url, @slug, callback
+  close: (id, callback) ->
+    url = @resource.queryString "#{@prefix}/#{id}/close"
+    @resource.get url, @slug, callback
 
-	open: (id, callback) ->
-		callback new Error 'missing id' unless id?
-		url = @resource.queryString "#{@prefix}/#{id}/open"
-		@resource.get url, @slug, callback
+  open: (id, callback) ->
+    url = @resource.queryString "#{@prefix}/#{id}/open"
+    @resource.get url, @slug, callback
 
-	cancel: (id, params, callback) ->
-		[params, callback] = [callback, params] if typeof params is 'function'
-		callback new Error 'missing id' unless id?
-		url = @resource.queryString "#{@prefix}/#{id}/cancel", params
-		@resource.get url, @slug, callback
+  cancel: (id, params, callback) ->
+    [params, callback] = [callback, params] if typeof params is 'function'
+    url = @resource.queryString "#{@prefix}/#{id}/cancel", params
+    @resource.get url, @slug, callback
 
-	events: (id, params, callback) ->
-		[params, callback] = [callback, params] if typeof params is 'function'
-		callback new Error 'missing id' unless id?
-		url = @resource.queryString "#{@prefix}/#{id}/events", params
-		@resource.get url, "events", callback
-
+  events: (id, params, callback) ->
+    [params, callback] = [callback, params] if typeof params is 'function'
+    url = @resource.queryString "#{@prefix}/#{id}/events", params
+    @resource.get url, "events", callback
 
 module.exports = Order

--- a/src/resources/page.coffee
+++ b/src/resources/page.coffee
@@ -2,20 +2,16 @@ Base = require './base'
 Metafields = require './metafield'
 
 class Page extends Base
-	slug: "page"
-	prefix: "/pages"
+  slug: "page"
+  prefix: "/pages"
 
-	constructor: (site) ->
-		@metafields = new Metafields(@prefix, site)
-		super(site)
-		
+  constructor: (site) ->
+    @metafields = new Metafields(@prefix, site)
+    super(site)
 
-	events: (id, params, callback) ->
-		[params, callback] = [callback, params] if typeof params is 'function'
-		callback new Error 'missing id' unless id?
-		url = @resource.queryString "#{@prefix}/#{id}/events", params
-		@resource.get url, "events", callback
-
-
+  events: (id, params, callback) ->
+    [params, callback] = [callback, params] if typeof params is 'function'
+    url = @resource.queryString "#{@prefix}/#{id}/events", params
+    @resource.get url, "events", callback
 
 module.exports = Page

--- a/src/resources/product.coffee
+++ b/src/resources/product.coffee
@@ -2,20 +2,16 @@ Base = require './base'
 Metafields = require './metafield'
 
 class Product extends Base
-	slug: "product"
-	prefix: "/products"
+  slug: "product"
+  prefix: "/products"
 
-	constructor: (site) ->
-		@metafields = new Metafields(@prefix, site)
-		super(site)
-		
+  constructor: (site) ->
+    @metafields = new Metafields(@prefix, site)
+    super(site)
 
-	events: (id, params, callback) ->
-		[params, callback] = [callback, params] if typeof params is 'function'
-		callback new Error 'missing id' unless id?
-		url = @resource.queryString "#{@prefix}/#{id}/events", params
-		@resource.get url, "events", callback
-
-
+  events: (id, params, callback) ->
+    [params, callback] = [callback, params] if typeof params is 'function'
+    url = @resource.queryString "#{@prefix}/#{id}/events", params
+    @resource.get url, "events", callback
 
 module.exports = Product

--- a/src/resources/product_variant.coffee
+++ b/src/resources/product_variant.coffee
@@ -2,23 +2,21 @@ BaseChild = require './base_child'
 Metafields = require './metafield'
 
 class ProductVariant extends BaseChild
-	parent: "/products"
-	slug: "variant"
-	child: "/variants"
+  parent: "/products"
+  slug: "variant"
+  child: "/variants"
 
-	constructor: (site) ->
-		super(site)
+  constructor: (site) ->
+    super(site)
 
-	get: (id, params, callback) ->
-		[params, callback] = [callback, params] if typeof params is 'function'
-		callback new Error 'missing id' unless id?
-		url = @resource.queryString "#{@site}#{@child}/#{id}", params
-		@resource.get url, @slug, callback
+  get: (id, params, callback) ->
+    [params, callback] = [callback, params] if typeof params is 'function'
+    url = @resource.queryString "#{@site}#{@child}/#{id}", params
+    @resource.get url, @slug, callback
 
 
-	update: (id, fields, callback) ->
-		callback new Error 'missing id' unless id?
-		url = @resource.queryString "#{@site}#{@child}/#{id}"
-		@resource.put url, @slug, fields, callback
+  update: (id, fields, callback) ->
+    url = @resource.queryString "#{@site}#{@child}/#{id}"
+    @resource.put url, @slug, fields, callback
 
-	module.exports = ProductVariant
+module.exports = ProductVariant

--- a/src/resources/recurring_application_charge.coffee
+++ b/src/resources/recurring_application_charge.coffee
@@ -1,15 +1,14 @@
 Base = require './base'
 
 class RecurringApplicationCharge extends Base
-	slug: "recurring_application_charge"
-	prefix: "/recurring_application_charges"
+  slug: "recurring_application_charge"
+  prefix: "/recurring_application_charges"
 
-	constructor: (site) ->
-		super(site)
+  constructor: (site) ->
+    super(site)
 
-	activate: (id, fields, callback) ->
-		callback new Error 'missing id' unless id?
-		url = @resource.queryString "#{@prefix}/#{id}/activate"
-		@resource.post url, @slug, fields, callback
+  activate: (id, fields, callback) ->
+    url = @resource.queryString "#{@prefix}/#{id}/activate"
+    @resource.post url, @slug, fields, callback
 
 module.exports = RecurringApplicationCharge

--- a/test/discount_test.js
+++ b/test/discount_test.js
@@ -51,38 +51,28 @@ describe('Discount', function () {
   it('should disable a discount', function (next) {
     var resBody = fixtures.disableResponseBody;
 
-    resource.disable('', function (err) {
-      err.should.be.an.Error();
-      err.message.should.be.exactly('invalid or missing id');
+    scope.post('/admin/discounts/680866/disable.json')
+      .reply(201, resBody);
 
-      scope.post('/admin/discounts/680866/disable.json')
-        .reply(201, resBody);
+    resource.disable(680866, function (err, res) {
+      if (err) return next(err);
 
-      resource.disable(680866, function (err, res) {
-        if (err) return next(err);
-
-        res.should.be.eql(resBody.discount);
-        next();
-      });
+      res.should.be.eql(resBody.discount);
+      next();
     });
   });
 
   it('should enable a discount', function (next) {
     var resBody = fixtures.enableResponseBody;
 
-    resource.enable(null, function (err) {
-      err.should.be.an.Error();
-      err.message.should.be.exactly('invalid or missing id');
+    scope.post('/admin/discounts/949676421/enable.json')
+      .reply(201, resBody);
 
-      scope.post('/admin/discounts/949676421/enable.json')
-        .reply(201, resBody);
+    resource.enable(949676421, function (err, res) {
+      if (err) return next(err);
 
-      resource.enable(949676421, function (err, res) {
-        if (err) return next(err);
-
-        res.should.be.eql(resBody.discount);
-        next();
-      });
+      res.should.be.eql(resBody.discount);
+      next();
     });
   });
 

--- a/test/gift_card_test.js
+++ b/test/gift_card_test.js
@@ -1,39 +1,39 @@
-var helper = require("./common.js");
-helper.setObject("gift_card");
+var helper = require('./common.js');
+helper.setObject('gift_card');
 
 var Resource = helper.resource();
 
 helper.nock(helper.test_shop)
 .get('/admin/gift_cards.json')
-.reply(200, helper.load("all"), {
+.reply(200, helper.load('all'), {
   server: 'nginx',
   status: '200 OK'
 });
 
 helper.nock(helper.test_shop)
 .get('/admin/gift_cards.json?status=enabled')
-.reply(200, helper.load("all"), {
+.reply(200, helper.load('all'), {
   server: 'nginx',
   status: '200 OK'
 });
 
 helper.nock(helper.test_shop)
 .get('/admin/gift_cards/48394658.json')
-.reply(200, helper.load("single"), {
+.reply(200, helper.load('single'), {
   server: 'nginx',
   status: '200 OK'
 });
 
 helper.nock(helper.test_shop)
 .get('/admin/gift_cards/count.json?status=enabled')
-.reply(200, helper.load("countAll"), {
+.reply(200, helper.load('countAll'), {
   server: 'nginx',
   status: '200 OK'
 });
 
 helper.nock(helper.test_shop)
 .get('/admin/gift_cards/count.json')
-.reply(200, helper.load("countAll"), {
+.reply(200, helper.load('countAll'), {
   server: 'nginx',
   status: '200 OK'
 });
@@ -41,13 +41,13 @@ helper.nock(helper.test_shop)
 helper.nock(helper.test_shop)
 .post('/admin/gift_cards.json', {
   gift_card: {
-    "note": "This is a note",
-    "initial_value": 100.0,
-    "code": "ABCD EFGH IJKL MNOP",
-    "template_suffix": "gift_cards.birthday.liquid"
+    note: 'This is a note',
+    initial_value: 100.0,
+    code: 'ABCD EFGH IJKL MNOP',
+    template_suffix: 'gift_cards.birthday.liquid'
   }
 })
-.reply(200, helper.load("createGiftCard"), {
+.reply(200, helper.load('createGiftCard'), {
   server: 'nginx',
   status: '200 OK'
 });
@@ -55,38 +55,38 @@ helper.nock(helper.test_shop)
 helper.nock(helper.test_shop)
 .put('/admin/gift_cards/1063936316.json', {
   gift_card: {
-    "note": "Updating with a new note"
+    note: 'Updating with a new note'
   }
 })
-.reply(200, helper.load("updateGiftCard"), {
+.reply(200, helper.load('updateGiftCard'), {
   server: 'nginx',
   status: '200 OK'
 });
 
 helper.nock(helper.test_shop)
 .post('/admin/gift_cards/1063936316/disable.json', {
-  'gift_card': {
-    'id': '1063936316'
+  gift_card: {
+    id: '1063936316'
   }
 })
-.reply(200, helper.load("disableGiftCard"), {
+.reply(200, helper.load('disableGiftCard'), {
   server: 'nginx',
   status: '200 OK'
 });
 
 helper.nock(helper.test_shop)
 .get('/admin/gift_cards/search.json?query=Bob')
-.reply(200, helper.load("search"), {
+.reply(200, helper.load('search'), {
   server: 'nginx',
   status: '200 OK'
 });
 
-describe('Gift card', function() {
+describe('Gift card', function () {
   var site = helper.endpoint;
   var resource = new Resource(site);
 
-  it('should get all gift cards', function(done) {
-    resource.getAll(function(err, res){
+  it('should get all gift cards', function (done) {
+    resource.getAll(function (err, res){
       res.should.not.be.empty;
       res[0].should.have.property('id');
       res[0].id.should.equal(48394658);
@@ -94,8 +94,8 @@ describe('Gift card', function() {
     });
   });
 
-  it('should get all gift cards with status enabled', function(done) {
-    resource.getByStatus('enabled', function(err, res){
+  it('should get all gift cards with status enabled', function (done) {
+    resource.getByStatus('enabled', function (err, res){
       res.should.not.be.empty;
       res[0].should.have.property('id');
       res[0].id.should.equal(48394658);
@@ -103,75 +103,67 @@ describe('Gift card', function() {
     });
   });
 
-  it('should throw error with invalid status', function(done) {
-    resource.getByStatus('invalid-status', function(err, res){
-      err.should.not.be.empty;
-      done();
-    });
-  });
-
-  it('able to get gift card by id', function(done) {
-    resource.get('48394658', function(err, res){
+  it('able to get gift card by id', function (done) {
+    resource.get('48394658', function (err, res){
       res.should.be.a.Object();
       res.id.should.equal(48394658);
       done();
     });
   });
 
-  it('get count all of gift cards', function(done) {
-    resource.getCount(function(err, res){
+  it('get count all of gift cards', function (done) {
+    resource.getCount(function (err, res){
       res.should.equal(3);
       done();
     });
   });
 
-  it('get count of gift cards by status', function(done) {
-    resource.getCountByStatus('enabled', function(err, res){
+  it('get count of gift cards by status', function (done) {
+    resource.getCountByStatus('enabled', function (err, res){
       res.should.equal(3);
       done();
     });
   });
 
-  it('should create gift card', function(done) {
+  it('should create gift card', function (done) {
     var giftCard = {
-      "note": "This is a note",
-      "initial_value": 100.0,
-      "code": "ABCD EFGH IJKL MNOP",
-      "template_suffix": "gift_cards.birthday.liquid"
-    }
+      note: 'This is a note',
+      initial_value: 100.0,
+      code: 'ABCD EFGH IJKL MNOP',
+      template_suffix: 'gift_cards.birthday.liquid'
+    };
 
-    resource.create(giftCard, function(err, res){
+    resource.create(giftCard, function (err, res){
       res.initial_value.should.equal(giftCard.initial_value.toFixed(2).toString());
       res.note.should.equal(giftCard.note);
       done();
     });
   });
 
-  it('should update gift card', function(done) {
+  it('should update gift card', function (done) {
     var giftCard = {
-      "note": "Updating with a new note"
-    }
+      note: 'Updating with a new note'
+    };
 
-    resource.update('1063936316', giftCard, function(err, res){
+    resource.update('1063936316', giftCard, function (err, res){
       res.note.should.equal(giftCard.note);
       done();
     });
   });
 
-  it('should disable gift card', function(done) {
-    resource.disable('1063936316', function(err, res){
+  it('should disable gift card', function (done) {
+    resource.disable('1063936316', function (err, res){
       res.disabled_at.should.not.be.null();
       done();
     });
   });
 
-  it('should search gift card', function(done) {
-    resource.search('Bob', function(err, res){
+  it('should search gift card', function (done) {
+    resource.search('Bob', function (err, res){
       res.should.not.be.empty;
       res[0].should.have.property('id');
       res[0].id.should.equal(1063936317);
       done();
     });
   });
-
 });


### PR DESCRIPTION
I think that the server-side validation is enough.
If the request payload is not valid the server will answer with a `4xx` error.
 
The documentation should list the arguments of each method and specify the required and optional ones.

The only valid reason to do client-side validation is to prevent requests from being sent when you already know that the payload is invalid but it does not worth the effort imho.

Closes #41.