### PR TITLE
Use qs instead of querystring

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "pluralize": "1.2.x",
+    "qs": "6.0.x",
     "request": "2.9.x",
     "singleton": "1.0.x"
   },

--- a/src/resource.coffee
+++ b/src/resource.coffee
@@ -1,6 +1,6 @@
-request = require 'request'
-querystring = require 'querystring'
 singleton = require 'singleton'
+request = require 'request'
+qs = require 'qs'
 
 class Resource extends singleton
 
@@ -38,7 +38,7 @@ class Resource extends singleton
       else if slug and slug isnt 'oauth'
         body = body[if typeof slug is 'object' then slug.long else slug]
 
-      process.nextTick -> callback err, body;
+      process.nextTick -> callback err, body
 
   get: (url, slug, callback) ->
     @__request__ url, slug, 'GET', callback
@@ -56,7 +56,7 @@ class Resource extends singleton
     query = "#{url}.#{format}"
 
     if params
-      query += "?" + querystring.stringify params
+      query += "?" + qs.stringify params, { arrayFormat: 'brackets' }
 
     return query
 


### PR DESCRIPTION
The built-in `querystring` module can't serialize nested object or provide a custom array format, but there are cases where this is needed.

An example is the [Asset](https://docs.shopify.com/api/asset) resource where the key of an asset is expressed as a nested object:

```
GET /admin/themes/#{id}/assets.json?asset[key]=assets/bg-body.gif&theme_id=828155753
``` 

Another example is the [CustomerAddress](https://docs.shopify.com/api/customeraddress) resource where arrays are expressed in the brackets form:

```
PUT /admin/customers/#{id}/addresses/set.json?address_ids[]=1053317300&operation=destroy
```

In order to handle these cases this patch replaces the built-in `querystring` module with the `qs` module. 