### PR TITLE
BUG: RecurringApplicationCharges.Activate returns an undefined body

### DIFF
--- a/lib/resource.js
+++ b/lib/resource.js
@@ -50,8 +50,8 @@
         }
         if (method === 'DELETE') {
           body = slug;
-        } else if (slug && slug !== 'oauth') {
-          body = body[typeof slug === 'object' ? slug.long : slug];
+        } else if (slug && slug !== 'oauth' && typeof(body) === "object") {
+            body = body[typeof slug === 'object' ? slug.long : slug];
         }
         return process.nextTick(function() {
           return callback(err, body);

--- a/src/resource.coffee
+++ b/src/resource.coffee
@@ -35,7 +35,7 @@ class Resource extends singleton
 
       if method is 'DELETE'
         body = slug
-      else if slug and slug isnt 'oauth'
+      else if slug and slug isnt 'oauth' and typeof body is 'object'
         body = body[if typeof slug is 'object' then slug.long else slug]
 
       process.nextTick -> callback err, body


### PR DESCRIPTION
The following code throws in resource.js because the response from Shopify is a null body but a 200 OK response.

export function acceptChargeCallback(id, chargeRecord, session, res) {
    session.recurringApplicationCharge.activate(id, {
        "recurring_application_charge": chargeRecord
    }, function (result) {
        res.redirect("/");
    });
}